### PR TITLE
feat(rooms): Implement inline room name editing and enhance topics

### DIFF
--- a/src/components/SubspaceTreeInput.tsx
+++ b/src/components/SubspaceTreeInput.tsx
@@ -69,6 +69,15 @@ const SubspaceNode = ({ name, control, remove, level = 0, users }) => {
         </IconButton>
       </Box>
 
+      <TextInput
+        source={`${name}.topic`}
+        label="resources.rooms.fields.topic" // Вам может понадобиться добавить ключ перевода
+        helperText={false}
+        fullWidth
+        multiline
+        // rows={2}
+      />
+
       {/* Добавляем AutocompleteInput для выбора создателя подпространства --> */}
       <AutocompleteInput
         source={`${name}.creator_id`}
@@ -95,7 +104,7 @@ const SubspaceNode = ({ name, control, remove, level = 0, users }) => {
 
       <Button
         label="resources.rooms.fields.subspaces.add_nested"
-        onClick={() => append({ name: "", subspaces: [] })}
+        onClick={() => append({ name: "", topic: "", subspaces: [] })}
         size="small"
         startIcon={<AddCircleIcon />}
         sx={{ marginTop: 1 }}
@@ -127,7 +136,7 @@ export const SubspaceTreeInput = ({ source, fullWidth, users }) => {
         ))}
         <Button
           label="resources.rooms.fields.subspaces.add_top_level"
-          onClick={() => append({ name: "", subspaces: [] })}
+          onClick={() => append({ name: "", topic: "", subspaces: [] })}
           sx={{ marginTop: 2 }}
           startIcon={<AddCircleIcon />}
         ></Button>


### PR DESCRIPTION
This commit introduces several improvements to room management:

- **Inline Name Editing:** Users can now edit the name of a room or space directly on the `RoomShow` page. This is achieved by sending an `m.room.name` state event via a new generic `sendStateEvent` method in the dataProvider.

- **Multiline Topic:** The text input for a room's topic on the creation form is now a multiline field, allowing for more descriptive text.

- **Topic Inheritance:** When creating a new room, it now automatically inherits the topic from its parent space, improving consistency.